### PR TITLE
WIP: ART-1895 golang CVEs

### DIFF
--- a/elliottlib/cli/__main__.py
+++ b/elliottlib/cli/__main__.py
@@ -53,6 +53,7 @@ from elliottlib.cli.rpmdiff_cli import rpmdiff_cli
 from elliottlib.cli.advisory_images_cli import advisory_images_cli
 from elliottlib.cli.advisory_impetus_cli import advisory_impetus_cli
 from elliottlib.cli.tag_builds_cli import tag_builds_cli
+from elliottlib.cli.golang_cve_cli import golang_cve_cli
 
 # 3rd party
 import bugzilla
@@ -811,6 +812,7 @@ cli.add_command(puddle_advisories_cli)
 cli.add_command(rpmdiff_cli)
 cli.add_command(tag_builds_cli)
 cli.add_command(tarball_sources_cli)
+cli.add_command(golang_cve_cli)
 
 # -----------------------------------------------------------------------------
 # CLI Entry point

--- a/elliottlib/cli/golang_cve_cli.py
+++ b/elliottlib/cli/golang_cve_cli.py
@@ -1,0 +1,90 @@
+# WIP WIP WIP
+
+import bugzilla
+import click
+import koji
+import re
+
+from packaging import version
+
+from elliottlib import brew, constants, Runtime
+from elliottlib.cli.common import cli
+
+
+pass_runtime = click.make_pass_decorator(Runtime)
+
+
+@cli.command('golang-cve', short_help='...')
+@click.option('--flaw-bz-id', required=True)
+@click.option('--fixed-in', multiple=True, required=True)
+@pass_runtime
+def golang_cve_cli(runtime, flaw_bz_id, fixed_in):
+
+    runtime.initialize()
+
+    ocp_version = '{MAJOR}.{MINOR}'.format(**runtime.group_config.vars)
+    bugzilla_url = runtime.gitdata.load_data(key='bugzilla').data['server']
+    brewhub_url = runtime.group_config.urls.brewhub or constants.BREW_HUB
+
+    bugzilla_api = bugzilla.Bugzilla(bugzilla_url)
+    tracker_bugs = get_tracker_bugs(bugzilla_api, flaw_bz_id, ocp_version)
+
+    report = {}
+    for bug in tracker_bugs:
+        report[extract_component_from_whiteboard(bug.whiteboard)] = {'bug': bug, 'rpms': []}
+
+    brew_session = koji.ClientSession(runtime.group_config.urls.brewhub or constants.BREW_HUB)
+    rpm_builds, _ = brew_session.listTaggedRPMS(
+        tag=runtime.group_config.build_profiles.rpm.default.targets[0],
+        latest=True
+    )
+
+    buildroots = {}
+
+    for rpm in rpm_builds:
+
+        if not rpm['buildroot_id'] in buildroots:
+            buildroots[rpm['buildroot_id']] = brew_session.getBuildrootListing(rpm['buildroot_id'])
+
+        buildroot = buildroots[rpm['buildroot_id']]
+        for dependency in buildroot:
+            if dependency['name'] == 'golang' or re.match(r'^go-toolset-\d\.\d{2}$', dependency['name']):
+                if rpm['name'] in report:
+                    report[rpm['name']]['rpms'].append(rpm)
+
+    for name, item in report.items():
+        print(name)
+        print('    bug: {} - {}'.format(item['bug'].id, item['bug'].status))
+        print('    rpms:')
+        for rpm in item['rpms']:
+            print('        {}-{}, buildroot {}, arch {}'.format(rpm['name'], rpm['release'], rpm['buildroot_id'], rpm['arch']))
+            for dependency in buildroots[rpm['buildroot_id']]:
+                if dependency['name'] == 'golang' or re.match(r'^go-toolset-\d\.\d{2}$', dependency['name']):
+                    print('            buildroot {} has {}, version {}'.format(rpm['buildroot_id'], dependency['name'], dependency['version']))
+                    fixed = False
+                    for v in fixed_in:
+                        if version.parse(dependency['version']) >= version.parse(v):
+                            fixed = True
+                    print('            CVE fixed: {}'.format(fixed))
+        print()
+
+
+def get_tracker_bugs(bugzilla_api, flaw_bz_id, ocp_version):
+    flaw_bz = bugzilla_api.getbug(flaw_bz_id)
+    all_tracker_bugs = bugzilla_api.getbugs(flaw_bz.depends_on)
+    tracker_bugs_for_ocp_version = filter(
+        lambda bug: only_major_minor(bug.version) == ocp_version,
+        all_tracker_bugs
+    )
+    return list(tracker_bugs_for_ocp_version)
+
+
+def only_major_minor(version):
+    match = re.match(r'(?P<major>\d+)\.(?P<minor>\d+)', version)
+    if not match:
+        return False
+    return '{}.{}'.format(match.group('major'), match.group('minor'))
+
+
+def extract_component_from_whiteboard(whiteboard_contents):
+    return whiteboard_contents.replace('component:', '')


### PR DESCRIPTION
### Work in progress

At the moment I'm just reading information and determining the status of each RPM (CVE fixed? True/False)

### Why in openshift-priv ?

Because I want to share the real output generated by this new elliott command, and it might reveal info we don't want to be public yet.

### Example output

```
$ elliott -g openshift-3.11 golang-cve --flaw-bz-id 1755969 --fixed-in 1.13.1 --fixed-in 1.12.10
2020-06-15 14:13:06,541 INFO Data clone directory already exists, checking commit sha
2020-06-15 14:13:07,113 INFO https://github.com/openshift/ocp-build-data.git is already cloned and latest
2020-06-15 14:13:07,176 INFO Using branch from group.yml: rhaos-3.11-rhel-7
ansible-service-broker
    bug: 1793809 - NEW
    rpms:
        ansible-service-broker-2.el7, buildroot 5183315, arch ppc64le
            buildroot 5183315 has go-toolset-1.10, version 1.10.8
            CVE fixed: False
        ansible-service-broker-2.el7, buildroot 5183314, arch s390x
            buildroot 5183314 has go-toolset-1.10, version 1.10.8
            CVE fixed: False
        ansible-service-broker-2.el7, buildroot 5183316, arch x86_64
            buildroot 5183316 has go-toolset-1.10, version 1.10.8
            CVE fixed: False
        ansible-service-broker-2.el7, buildroot 5183317, arch aarch64
            buildroot 5183317 has go-toolset-1.10, version 1.10.8
            CVE fixed: False
        ansible-service-broker-2.el7, buildroot 5183317, arch src
            buildroot 5183317 has go-toolset-1.10, version 1.10.8
            CVE fixed: False

apb
    bug: 1793810 - NEW
    rpms:
        apb-1.el7, buildroot 5198688, arch ppc64le
            buildroot 5198688 has go-toolset-1.10, version 1.10.8
            CVE fixed: False
        apb-1.el7, buildroot 5198689, arch s390x
            buildroot 5198689 has go-toolset-1.10, version 1.10.8
            CVE fixed: False
        apb-1.el7, buildroot 5198686, arch x86_64
            buildroot 5198686 has go-toolset-1.10, version 1.10.8
            CVE fixed: False
        apb-1.el7, buildroot 5198687, arch aarch64
            buildroot 5198687 has go-toolset-1.10, version 1.10.8
            CVE fixed: False
        apb-1.el7, buildroot 5198687, arch src
            buildroot 5198687 has go-toolset-1.10, version 1.10.8
            CVE fixed: False

atomic-enterprise-service-catalog
    bug: 1793811 - NEW
    rpms:
        atomic-enterprise-service-catalog-1.git.1.d1e3501.el7, buildroot 6067141, arch ppc64le
            buildroot 6067141 has go-toolset-1.10, version 1.10.8
            CVE fixed: False
        atomic-enterprise-service-catalog-1.git.1.d1e3501.el7, buildroot 6067121, arch s390x
            buildroot 6067121 has go-toolset-1.10, version 1.10.8
            CVE fixed: False
        atomic-enterprise-service-catalog-1.git.1.d1e3501.el7, buildroot 6067120, arch x86_64
            buildroot 6067120 has go-toolset-1.10, version 1.10.8
            CVE fixed: False
        atomic-enterprise-service-catalog-1.git.1.d1e3501.el7, buildroot 6067124, arch aarch64
            buildroot 6067124 has go-toolset-1.10, version 1.10.8
            CVE fixed: False
        atomic-enterprise-service-catalog-1.git.1.d1e3501.el7, buildroot 6067124, arch src
            buildroot 6067124 has go-toolset-1.10, version 1.10.8
            CVE fixed: False

atomic-openshift
    bug: 1793812 - NEW
    rpms:
        atomic-openshift-1.git.0.a5bc32f.el7, buildroot 6066990, arch ppc64le
            buildroot 6066990 has go-toolset-1.10, version 1.10.8
            CVE fixed: False
        atomic-openshift-1.git.0.a5bc32f.el7, buildroot 6066992, arch s390x
            buildroot 6066992 has go-toolset-1.10, version 1.10.8
            CVE fixed: False
        atomic-openshift-1.git.0.a5bc32f.el7, buildroot 6066989, arch x86_64
            buildroot 6066989 has go-toolset-1.10, version 1.10.8
            CVE fixed: False
        atomic-openshift-1.git.0.a5bc32f.el7, buildroot 6066988, arch aarch64
            buildroot 6066988 has go-toolset-1.10, version 1.10.8
            CVE fixed: False
        atomic-openshift-1.git.0.a5bc32f.el7, buildroot 6066988, arch src
            buildroot 6066988 has go-toolset-1.10, version 1.10.8
            CVE fixed: False

atomic-openshift-cluster-autoscaler
    bug: 1793813 - NEW
    rpms:
        atomic-openshift-cluster-autoscaler-1.git.1.e7433c6.el7, buildroot 6067147, arch ppc64le
            buildroot 6067147 has golang, version 1.9.7
            CVE fixed: False
        atomic-openshift-cluster-autoscaler-1.git.1.e7433c6.el7, buildroot 6067150, arch s390x
            buildroot 6067150 has golang, version 1.9.7
            CVE fixed: False
        atomic-openshift-cluster-autoscaler-1.git.1.e7433c6.el7, buildroot 6067149, arch x86_64
            buildroot 6067149 has golang, version 1.9.7
            CVE fixed: False
        atomic-openshift-cluster-autoscaler-1.git.1.e7433c6.el7, buildroot 6067160, arch aarch64
            buildroot 6067160 has golang, version 1.9.7
            CVE fixed: False
        atomic-openshift-cluster-autoscaler-1.git.1.e7433c6.el7, buildroot 6067160, arch src
            buildroot 6067160 has golang, version 1.9.7
            CVE fixed: False

atomic-openshift-descheduler
    bug: 1793814 - NEW
    rpms:
        atomic-openshift-descheduler-1.git.1.71361e4.el7, buildroot 6067153, arch ppc64le
            buildroot 6067153 has golang, version 1.9.7
            CVE fixed: False
        atomic-openshift-descheduler-1.git.1.71361e4.el7, buildroot 6067161, arch s390x
            buildroot 6067161 has golang, version 1.9.7
            CVE fixed: False
        atomic-openshift-descheduler-1.git.1.71361e4.el7, buildroot 6067157, arch x86_64
            buildroot 6067157 has golang, version 1.9.7
            CVE fixed: False
        atomic-openshift-descheduler-1.git.1.71361e4.el7, buildroot 6067155, arch aarch64
            buildroot 6067155 has golang, version 1.9.7
            CVE fixed: False
        atomic-openshift-descheduler-1.git.1.71361e4.el7, buildroot 6067155, arch src
            buildroot 6067155 has golang, version 1.9.7
            CVE fixed: False

atomic-openshift-dockerregistry
    bug: 1793815 - NEW
    rpms:
        atomic-openshift-dockerregistry-1.git.1.e5150dd.el7, buildroot 6067151, arch ppc64le
            buildroot 6067151 has go-toolset-1.10, version 1.10.8
            CVE fixed: False
        atomic-openshift-dockerregistry-1.git.1.e5150dd.el7, buildroot 6067152, arch s390x
            buildroot 6067152 has go-toolset-1.10, version 1.10.8
            CVE fixed: False
        atomic-openshift-dockerregistry-1.git.1.e5150dd.el7, buildroot 6067156, arch x86_64
            buildroot 6067156 has go-toolset-1.10, version 1.10.8
            CVE fixed: False
        atomic-openshift-dockerregistry-1.git.1.e5150dd.el7, buildroot 6067154, arch aarch64
            buildroot 6067154 has go-toolset-1.10, version 1.10.8
            CVE fixed: False
        atomic-openshift-dockerregistry-1.git.1.e5150dd.el7, buildroot 6067154, arch src
            buildroot 6067154 has go-toolset-1.10, version 1.10.8
            CVE fixed: False

atomic-openshift-metrics-server
    bug: 1793816 - NEW
    rpms:
        atomic-openshift-metrics-server-1.git.1.8c5f5b4.el7, buildroot 6067139, arch ppc64le
            buildroot 6067139 has golang, version 1.9.7
            CVE fixed: False
        atomic-openshift-metrics-server-1.git.1.8c5f5b4.el7, buildroot 6067117, arch s390x
            buildroot 6067117 has golang, version 1.9.7
            CVE fixed: False
        atomic-openshift-metrics-server-1.git.1.8c5f5b4.el7, buildroot 6067119, arch x86_64
            buildroot 6067119 has golang, version 1.9.7
            CVE fixed: False
        atomic-openshift-metrics-server-1.git.1.8c5f5b4.el7, buildroot 6067116, arch aarch64
            buildroot 6067116 has golang, version 1.9.7
            CVE fixed: False
        atomic-openshift-metrics-server-1.git.1.8c5f5b4.el7, buildroot 6067116, arch src
            buildroot 6067116 has golang, version 1.9.7
            CVE fixed: False

atomic-openshift-node-problem-detector
    bug: 1793817 - NEW
    rpms:
        atomic-openshift-node-problem-detector-1.git.1.d41afaf.el7, buildroot 6067126, arch ppc64le
            buildroot 6067126 has golang, version 1.9.7
            CVE fixed: False
        atomic-openshift-node-problem-detector-1.git.1.d41afaf.el7, buildroot 6067114, arch s390x
            buildroot 6067114 has golang, version 1.9.7
            CVE fixed: False
        atomic-openshift-node-problem-detector-1.git.1.d41afaf.el7, buildroot 6067112, arch x86_64
            buildroot 6067112 has golang, version 1.9.7
            CVE fixed: False
        atomic-openshift-node-problem-detector-1.git.1.d41afaf.el7, buildroot 6067110, arch aarch64
            buildroot 6067110 has golang, version 1.9.7
            CVE fixed: False
        atomic-openshift-node-problem-detector-1.git.1.d41afaf.el7, buildroot 6067110, arch src
            buildroot 6067110 has golang, version 1.9.7
            CVE fixed: False

atomic-openshift-service-idler
    bug: 1793818 - NEW
    rpms:
        atomic-openshift-service-idler-1.git.1.424e270.el7, buildroot 6067145, arch ppc64le
            buildroot 6067145 has golang, version 1.9.7
            CVE fixed: False
        atomic-openshift-service-idler-1.git.1.424e270.el7, buildroot 6067136, arch s390x
            buildroot 6067136 has golang, version 1.9.7
            CVE fixed: False
        atomic-openshift-service-idler-1.git.1.424e270.el7, buildroot 6067131, arch x86_64
            buildroot 6067131 has golang, version 1.9.7
            CVE fixed: False
        atomic-openshift-service-idler-1.git.1.424e270.el7, buildroot 6067133, arch aarch64
            buildroot 6067133 has golang, version 1.9.7
            CVE fixed: False
        atomic-openshift-service-idler-1.git.1.424e270.el7, buildroot 6067133, arch src
            buildroot 6067133 has golang, version 1.9.7
            CVE fixed: False

atomic-openshift-web-console
    bug: 1793819 - NEW
    rpms:
        atomic-openshift-web-console-1.git.1.0f92c9e.el7, buildroot 6067146, arch ppc64le
            buildroot 6067146 has golang, version 1.9.7
            CVE fixed: False
        atomic-openshift-web-console-1.git.1.0f92c9e.el7, buildroot 6067137, arch s390x
            buildroot 6067137 has golang, version 1.9.7
            CVE fixed: False
        atomic-openshift-web-console-1.git.1.0f92c9e.el7, buildroot 6067138, arch x86_64
            buildroot 6067138 has golang, version 1.9.7
            CVE fixed: False
        atomic-openshift-web-console-1.git.1.0f92c9e.el7, buildroot 6067144, arch aarch64
            buildroot 6067144 has golang, version 1.9.7
            CVE fixed: False
        atomic-openshift-web-console-1.git.1.0f92c9e.el7, buildroot 6067144, arch src
            buildroot 6067144 has golang, version 1.9.7
            CVE fixed: False

containernetworking-plugins
    bug: 1793820 - NEW
    rpms:
        containernetworking-plugins-6.el7, buildroot 5204785, arch ppc64le
            buildroot 5204785 has go-toolset-1.10, version 1.10.8
            CVE fixed: False
        containernetworking-plugins-6.el7, buildroot 5204784, arch s390x
            buildroot 5204784 has go-toolset-1.10, version 1.10.8
            CVE fixed: False
        containernetworking-plugins-6.el7, buildroot 5204782, arch x86_64
            buildroot 5204782 has go-toolset-1.10, version 1.10.8
            CVE fixed: False
        containernetworking-plugins-6.el7, buildroot 5204783, arch aarch64
            buildroot 5204783 has go-toolset-1.10, version 1.10.8
            CVE fixed: False
        containernetworking-plugins-6.el7, buildroot 5204783, arch src
            buildroot 5204783 has go-toolset-1.10, version 1.10.8
            CVE fixed: False

cri-o
    bug: 1793821 - NEW
    rpms:
        cri-o-0.9.dev.rhaos3.11.git6d43aae.el7, buildroot 5927786, arch ppc64le
            buildroot 5927786 has go-toolset-1.10, version 1.10.8
            CVE fixed: False
        cri-o-0.9.dev.rhaos3.11.git6d43aae.el7, buildroot 5927785, arch s390x
            buildroot 5927785 has go-toolset-1.10, version 1.10.8
            CVE fixed: False
        cri-o-0.9.dev.rhaos3.11.git6d43aae.el7, buildroot 5927793, arch x86_64
            buildroot 5927793 has go-toolset-1.10, version 1.10.8
            CVE fixed: False
        cri-o-0.9.dev.rhaos3.11.git6d43aae.el7, buildroot 5927792, arch aarch64
            buildroot 5927792 has go-toolset-1.10, version 1.10.8
            CVE fixed: False
        cri-o-0.9.dev.rhaos3.11.git6d43aae.el7, buildroot 5927792, arch src
            buildroot 5927792 has go-toolset-1.10, version 1.10.8
            CVE fixed: False

cri-tools
    bug: 1793822 - NEW
    rpms:
        cri-tools-3.rhaos3.11.gitedabfb5.el7, buildroot 6018364, arch ppc64le
            buildroot 6018364 has go-toolset-1.10, version 1.10.8
            CVE fixed: False
        cri-tools-3.rhaos3.11.gitedabfb5.el7, buildroot 6018365, arch s390x
            buildroot 6018365 has go-toolset-1.10, version 1.10.8
            CVE fixed: False
        cri-tools-3.rhaos3.11.gitedabfb5.el7, buildroot 6018362, arch x86_64
            buildroot 6018362 has go-toolset-1.10, version 1.10.8
            CVE fixed: False
        cri-tools-3.rhaos3.11.gitedabfb5.el7, buildroot 6018363, arch aarch64
            buildroot 6018363 has go-toolset-1.10, version 1.10.8
            CVE fixed: False
        cri-tools-3.rhaos3.11.gitedabfb5.el7, buildroot 6018363, arch src
            buildroot 6018363 has go-toolset-1.10, version 1.10.8
            CVE fixed: False

csi-attacher
    bug: 1793823 - NEW
    rpms:
        csi-attacher-4.git27299be.el7, buildroot 5210864, arch ppc64le
            buildroot 5210864 has golang, version 1.9.7
            CVE fixed: False
        csi-attacher-4.git27299be.el7, buildroot 5210865, arch s390x
            buildroot 5210865 has golang, version 1.9.7
            CVE fixed: False
        csi-attacher-4.git27299be.el7, buildroot 5210862, arch x86_64
            buildroot 5210862 has golang, version 1.9.7
            CVE fixed: False
        csi-attacher-4.git27299be.el7, buildroot 5210863, arch aarch64
            buildroot 5210863 has golang, version 1.9.7
            CVE fixed: False
        csi-attacher-4.git27299be.el7, buildroot 5210863, arch src
            buildroot 5210863 has golang, version 1.9.7
            CVE fixed: False

csi-driver-registrar
    bug: 1793824 - NEW
    rpms:
        csi-driver-registrar-2.el7, buildroot 5210871, arch ppc64le
            buildroot 5210871 has golang, version 1.9.7
            CVE fixed: False
        csi-driver-registrar-2.el7, buildroot 5210868, arch s390x
            buildroot 5210868 has golang, version 1.9.7
            CVE fixed: False
        csi-driver-registrar-2.el7, buildroot 5210869, arch x86_64
            buildroot 5210869 has golang, version 1.9.7
            CVE fixed: False
        csi-driver-registrar-2.el7, buildroot 5210867, arch aarch64
            buildroot 5210867 has golang, version 1.9.7
            CVE fixed: False
        csi-driver-registrar-2.el7, buildroot 5210867, arch src
            buildroot 5210867 has golang, version 1.9.7
            CVE fixed: False

csi-livenessprobe
    bug: 1793825 - NEW
    rpms:
        csi-livenessprobe-2.gitff5b6a0.el7, buildroot 5210876, arch ppc64le
            buildroot 5210876 has golang, version 1.9.7
            CVE fixed: False
        csi-livenessprobe-2.gitff5b6a0.el7, buildroot 5210873, arch s390x
            buildroot 5210873 has golang, version 1.9.7
            CVE fixed: False
        csi-livenessprobe-2.gitff5b6a0.el7, buildroot 5210874, arch x86_64
            buildroot 5210874 has golang, version 1.9.7
            CVE fixed: False
        csi-livenessprobe-2.gitff5b6a0.el7, buildroot 5210872, arch aarch64
            buildroot 5210872 has golang, version 1.9.7
            CVE fixed: False
        csi-livenessprobe-2.gitff5b6a0.el7, buildroot 5210872, arch src
            buildroot 5210872 has golang, version 1.9.7
            CVE fixed: False

csi-provisioner
    bug: 1793826 - NEW
    rpms:
        csi-provisioner-3.el7, buildroot 5210880, arch ppc64le
            buildroot 5210880 has golang, version 1.9.7
            CVE fixed: False
        csi-provisioner-3.el7, buildroot 5210877, arch s390x
            buildroot 5210877 has golang, version 1.9.7
            CVE fixed: False
        csi-provisioner-3.el7, buildroot 5210878, arch x86_64
            buildroot 5210878 has golang, version 1.9.7
            CVE fixed: False
        csi-provisioner-3.el7, buildroot 5210879, arch aarch64
            buildroot 5210879 has golang, version 1.9.7
            CVE fixed: False
        csi-provisioner-3.el7, buildroot 5210879, arch src
            buildroot 5210879 has golang, version 1.9.7
            CVE fixed: False

golang-github-openshift-oauth-proxy
    bug: 1793827 - NEW
    rpms:
        golang-github-openshift-oauth-proxy-1.git.1.db200ae.el7, buildroot 6067118, arch ppc64le
            buildroot 6067118 has go-toolset-1.10, version 1.10.8
            CVE fixed: False
        golang-github-openshift-oauth-proxy-1.git.1.db200ae.el7, buildroot 6067113, arch s390x
            buildroot 6067113 has go-toolset-1.10, version 1.10.8
            CVE fixed: False
        golang-github-openshift-oauth-proxy-1.git.1.db200ae.el7, buildroot 6067108, arch x86_64
            buildroot 6067108 has go-toolset-1.10, version 1.10.8
            CVE fixed: False
        golang-github-openshift-oauth-proxy-1.git.1.db200ae.el7, buildroot 6067109, arch aarch64
            buildroot 6067109 has go-toolset-1.10, version 1.10.8
            CVE fixed: False
        golang-github-openshift-oauth-proxy-1.git.1.db200ae.el7, buildroot 6067109, arch src
            buildroot 6067109 has go-toolset-1.10, version 1.10.8
            CVE fixed: False

golang-github-openshift-prometheus-alert-buffer
    bug: 1793828 - NEW
    rpms:
        golang-github-openshift-prometheus-alert-buffer-3.gitceca8c1.el7, buildroot 5183194, arch ppc64le
            buildroot 5183194 has go-toolset-1.12, version 1.12.8
            CVE fixed: False
        golang-github-openshift-prometheus-alert-buffer-3.gitceca8c1.el7, buildroot 5183192, arch s390x
            buildroot 5183192 has go-toolset-1.12, version 1.12.8
            CVE fixed: False
        golang-github-openshift-prometheus-alert-buffer-3.gitceca8c1.el7, buildroot 5183190, arch x86_64
            buildroot 5183190 has go-toolset-1.12, version 1.12.8
            CVE fixed: False
        golang-github-openshift-prometheus-alert-buffer-3.gitceca8c1.el7, buildroot 5183191, arch aarch64
            buildroot 5183191 has go-toolset-1.12, version 1.12.8
            CVE fixed: False
        golang-github-openshift-prometheus-alert-buffer-3.gitceca8c1.el7, buildroot 5183191, arch src
            buildroot 5183191 has go-toolset-1.12, version 1.12.8
            CVE fixed: False

golang-github-prometheus-alertmanager
    bug: 1793829 - NEW
    rpms:
        golang-github-prometheus-alertmanager-1.git.1.abfb991.el7, buildroot 6067088, arch src
            buildroot 6067088 has go-toolset-1.10, version 1.10.8
            CVE fixed: False

golang-github-prometheus-node_exporter
    bug: 1793830 - NEW
    rpms:
        golang-github-prometheus-node_exporter-1.git.1.0216923.el7, buildroot 6067100, arch src
            buildroot 6067100 has go-toolset-1.10, version 1.10.8
            CVE fixed: False

golang-github-prometheus-prometheus
    bug: 1793831 - NEW
    rpms:
        golang-github-prometheus-prometheus-1.git.1.3c936ee.el7, buildroot 6067125, arch src
            buildroot 6067125 has go-toolset-1.10, version 1.10.8
            CVE fixed: False

golang-github-prometheus-promu
    bug: 1793832 - NEW
    rpms:
        golang-github-prometheus-promu-5.git85ceabc.el7, buildroot 5200803, arch ppc64le
            buildroot 5200803 has golang, version 1.9.7
            CVE fixed: False
        golang-github-prometheus-promu-5.git85ceabc.el7, buildroot 5200805, arch s390x
            buildroot 5200805 has golang, version 1.9.7
            CVE fixed: False
        golang-github-prometheus-promu-5.git85ceabc.el7, buildroot 5200802, arch x86_64
            buildroot 5200802 has golang, version 1.9.7
            CVE fixed: False
        golang-github-prometheus-promu-5.git85ceabc.el7, buildroot 5200804, arch aarch64
            buildroot 5200804 has golang, version 1.9.7
            CVE fixed: False
        golang-github-prometheus-promu-5.git85ceabc.el7, buildroot 5200804, arch src
            buildroot 5200804 has golang, version 1.9.7
            CVE fixed: False

hawkular-openshift-agent
    bug: 1793833 - NEW
    rpms:
        hawkular-openshift-agent-3.el7, buildroot 5188281, arch ppc64le
            buildroot 5188281 has golang, version 1.9.7
            CVE fixed: False
        hawkular-openshift-agent-3.el7, buildroot 5188278, arch s390x
            buildroot 5188278 has golang, version 1.9.7
            CVE fixed: False
        hawkular-openshift-agent-3.el7, buildroot 5188280, arch x86_64
            buildroot 5188280 has golang, version 1.9.7
            CVE fixed: False
        hawkular-openshift-agent-3.el7, buildroot 5188282, arch aarch64
            buildroot 5188282 has golang, version 1.9.7
            CVE fixed: False
        hawkular-openshift-agent-3.el7, buildroot 5188282, arch src
            buildroot 5188282 has golang, version 1.9.7
            CVE fixed: False

heapster
    bug: 1793835 - NEW
    rpms:
        heapster-4.el7, buildroot 5188179, arch ppc64le
            buildroot 5188179 has golang, version 1.9.7
            CVE fixed: False
        heapster-4.el7, buildroot 5188178, arch s390x
            buildroot 5188178 has golang, version 1.9.7
            CVE fixed: False
        heapster-4.el7, buildroot 5188176, arch x86_64
            buildroot 5188176 has golang, version 1.9.7
            CVE fixed: False
        heapster-4.el7, buildroot 5188174, arch aarch64
            buildroot 5188174 has golang, version 1.9.7
            CVE fixed: False
        heapster-4.el7, buildroot 5188174, arch src
            buildroot 5188174 has golang, version 1.9.7
            CVE fixed: False

image-inspector
    bug: 1793836 - NEW
    rpms:
        image-inspector-4.el7, buildroot 5200984, arch ppc64le
            buildroot 5200984 has golang, version 1.9.7
            CVE fixed: False
        image-inspector-4.el7, buildroot 5200981, arch s390x
            buildroot 5200981 has golang, version 1.9.7
            CVE fixed: False
        image-inspector-4.el7, buildroot 5200982, arch x86_64
            buildroot 5200982 has golang, version 1.9.7
            CVE fixed: False
        image-inspector-4.el7, buildroot 5200985, arch aarch64
            buildroot 5200985 has golang, version 1.9.7
            CVE fixed: False
        image-inspector-4.el7, buildroot 5200985, arch src
            buildroot 5200985 has golang, version 1.9.7
            CVE fixed: False

openshift-enterprise-autoheal
    bug: 1793837 - NEW
    rpms:
        openshift-enterprise-autoheal-1.git.1.2756a13.el7, buildroot 6067115, arch ppc64le
            buildroot 6067115 has golang, version 1.9.7
            CVE fixed: False
        openshift-enterprise-autoheal-1.git.1.2756a13.el7, buildroot 6067107, arch s390x
            buildroot 6067107 has golang, version 1.9.7
            CVE fixed: False
        openshift-enterprise-autoheal-1.git.1.2756a13.el7, buildroot 6067102, arch x86_64
            buildroot 6067102 has golang, version 1.9.7
            CVE fixed: False
        openshift-enterprise-autoheal-1.git.1.2756a13.el7, buildroot 6067104, arch aarch64
            buildroot 6067104 has golang, version 1.9.7
            CVE fixed: False
        openshift-enterprise-autoheal-1.git.1.2756a13.el7, buildroot 6067104, arch src
            buildroot 6067104 has golang, version 1.9.7
            CVE fixed: False

openshift-enterprise-cluster-capacity
    bug: 1793838 - NEW
    rpms:
        openshift-enterprise-cluster-capacity-1.git.1.2e0c082.el7, buildroot 6067163, arch ppc64le
            buildroot 6067163 has golang, version 1.9.7
            CVE fixed: False
        openshift-enterprise-cluster-capacity-1.git.1.2e0c082.el7, buildroot 6067162, arch s390x
            buildroot 6067162 has golang, version 1.9.7
            CVE fixed: False
        openshift-enterprise-cluster-capacity-1.git.1.2e0c082.el7, buildroot 6067158, arch x86_64
            buildroot 6067158 has golang, version 1.9.7
            CVE fixed: False
        openshift-enterprise-cluster-capacity-1.git.1.2e0c082.el7, buildroot 6067159, arch aarch64
            buildroot 6067159 has golang, version 1.9.7
            CVE fixed: False
        openshift-enterprise-cluster-capacity-1.git.1.2e0c082.el7, buildroot 6067159, arch src
            buildroot 6067159 has golang, version 1.9.7
            CVE fixed: False

openshift-enterprise-image-registry
    bug: 1793839 - NEW
    rpms:
        openshift-enterprise-image-registry-2.git.216.b6b90bb.el7, buildroot 5203984, arch ppc64le
            buildroot 5203984 has golang, version 1.9.7
            CVE fixed: False
        openshift-enterprise-image-registry-2.git.216.b6b90bb.el7, buildroot 5203982, arch s390x
            buildroot 5203982 has golang, version 1.9.7
            CVE fixed: False
        openshift-enterprise-image-registry-2.git.216.b6b90bb.el7, buildroot 5203980, arch x86_64
            buildroot 5203980 has golang, version 1.9.7
            CVE fixed: False
        openshift-enterprise-image-registry-2.git.216.b6b90bb.el7, buildroot 5203981, arch aarch64
            buildroot 5203981 has golang, version 1.9.7
            CVE fixed: False
        openshift-enterprise-image-registry-2.git.216.b6b90bb.el7, buildroot 5203981, arch src
            buildroot 5203981 has golang, version 1.9.7
            CVE fixed: False

openshift-eventrouter
    bug: 1793840 - NEW
    rpms:
        openshift-eventrouter-4.git7c289cc.el7, buildroot 5264299, arch ppc64le
            buildroot 5264299 has go-toolset-1.12, version 1.12.8
            CVE fixed: False
        openshift-eventrouter-4.git7c289cc.el7, buildroot 5264294, arch s390x
            buildroot 5264294 has go-toolset-1.12, version 1.12.8
            CVE fixed: False
        openshift-eventrouter-4.git7c289cc.el7, buildroot 5264296, arch x86_64
            buildroot 5264296 has go-toolset-1.12, version 1.12.8
            CVE fixed: False
        openshift-eventrouter-4.git7c289cc.el7, buildroot 5264295, arch aarch64
            buildroot 5264295 has go-toolset-1.12, version 1.12.8
            CVE fixed: False
        openshift-eventrouter-4.git7c289cc.el7, buildroot 5264295, arch src
            buildroot 5264295 has go-toolset-1.12, version 1.12.8
            CVE fixed: False

openshift-external-storage
    bug: 1793841 - NEW
    rpms:
        openshift-external-storage-10.gitd3c94f0.el7, buildroot 5376343, arch src
            buildroot 5376343 has go-toolset-1.10, version 1.10.8
            CVE fixed: False

openshift-monitor-project-lifecycle
    bug: 1793842 - NEW
    rpms:
        openshift-monitor-project-lifecycle-2.git.59.7b59e29.el7, buildroot 5210815, arch ppc64le
            buildroot 5210815 has golang, version 1.9.7
            CVE fixed: False
        openshift-monitor-project-lifecycle-2.git.59.7b59e29.el7, buildroot 5210813, arch s390x
            buildroot 5210813 has golang, version 1.9.7
            CVE fixed: False
        openshift-monitor-project-lifecycle-2.git.59.7b59e29.el7, buildroot 5210812, arch x86_64
            buildroot 5210812 has golang, version 1.9.7
            CVE fixed: False
        openshift-monitor-project-lifecycle-2.git.59.7b59e29.el7, buildroot 5210814, arch aarch64
            buildroot 5210814 has golang, version 1.9.7
            CVE fixed: False
        openshift-monitor-project-lifecycle-2.git.59.7b59e29.el7, buildroot 5210814, arch src
            buildroot 5210814 has golang, version 1.9.7
            CVE fixed: False

openshift-monitor-sample-app
    bug: 1793843 - NEW
    rpms:
        openshift-monitor-sample-app-1.git.5.f6d0188.el7, buildroot 4601144, arch ppc64le
            buildroot 4601144 has golang, version 1.9.4
            CVE fixed: False
        openshift-monitor-sample-app-1.git.5.f6d0188.el7, buildroot 4601143, arch s390x
            buildroot 4601143 has golang, version 1.9.4
            CVE fixed: False
        openshift-monitor-sample-app-1.git.5.f6d0188.el7, buildroot 4601145, arch x86_64
            buildroot 4601145 has golang, version 1.9.4
            CVE fixed: False
        openshift-monitor-sample-app-1.git.5.f6d0188.el7, buildroot 4601142, arch aarch64
            buildroot 4601142 has golang, version 1.9.4
            CVE fixed: False
        openshift-monitor-sample-app-1.git.5.f6d0188.el7, buildroot 4601142, arch src
            buildroot 4601142 has golang, version 1.9.4
            CVE fixed: False

openvswitch-ovn-kubernetes
    bug: 1793844 - NEW
    rpms:
        openvswitch-ovn-kubernetes-3.el7, buildroot 5201205, arch ppc64le
            buildroot 5201205 has golang, version 1.9.7
            CVE fixed: False
        openvswitch-ovn-kubernetes-3.el7, buildroot 5201201, arch s390x
            buildroot 5201201 has golang, version 1.9.7
            CVE fixed: False
        openvswitch-ovn-kubernetes-3.el7, buildroot 5201200, arch x86_64
            buildroot 5201200 has golang, version 1.9.7
            CVE fixed: False
        openvswitch-ovn-kubernetes-3.el7, buildroot 5201202, arch aarch64
            buildroot 5201202 has golang, version 1.9.7
            CVE fixed: False
        openvswitch-ovn-kubernetes-3.el7, buildroot 5201202, arch src
            buildroot 5201202 has golang, version 1.9.7
            CVE fixed: False

podman
    bug: 1793845 - NEW
    rpms:
        podman-5.git37a2afe.el7_5, buildroot 4465047, arch ppc64le
            buildroot 4465047 has golang, version 1.9.2
            CVE fixed: False
        podman-5.git37a2afe.el7_5, buildroot 4465096, arch s390x
            buildroot 4465096 has golang, version 1.9.2
            CVE fixed: False
        podman-5.git37a2afe.el7_5, buildroot 4465046, arch x86_64
            buildroot 4465046 has golang, version 1.9.2
            CVE fixed: False
        podman-5.git37a2afe.el7_5, buildroot 4465048, arch aarch64
            buildroot 4465048 has golang, version 1.9.2
            CVE fixed: False
        podman-5.git37a2afe.el7_5, buildroot 4465048, arch src
            buildroot 4465048 has golang, version 1.9.2
            CVE fixed: False
```